### PR TITLE
Optional keys for templates by marking them with "?"

### DIFF
--- a/src/main/java/com/renomad/minum/templating/TemplateProcessor.java
+++ b/src/main/java/com/renomad/minum/templating/TemplateProcessor.java
@@ -82,7 +82,7 @@ public final class TemplateProcessor {
         if (!unusedKeys.isEmpty()) {
             throw new TemplateRenderException("No corresponding key in template found for these keys: " + String.join(", ", unusedKeys));
         }
-        
+
         return builder.toString();
     }
 
@@ -165,7 +165,7 @@ public final class TemplateProcessor {
 
     static StringBuilder processSectionInside(StringBuilder builder, List<TemplateSection> tSections) {
         if (!builder.isEmpty()) {
-            tSections.add(new TemplateSection(null, builder.toString(), 0));
+            tSections.add(new TemplateSection(null, builder.toString(), 0, false));
             builder = new StringBuilder();
         }
         return builder;

--- a/src/main/java/com/renomad/minum/templating/TemplateProcessor.java
+++ b/src/main/java/com/renomad/minum/templating/TemplateProcessor.java
@@ -65,11 +65,6 @@ public final class TemplateProcessor {
         StringBuilder builder = new StringBuilder();
         for (TemplateSection templateSection : templateSections) {
             RenderingResult result = templateSection.render(myMap);
-            if (result.renderedSection().isEmpty() &&
-                    templateSection.isOptional &&
-                    !builder.isEmpty())
-                // Remove last character if possible, prevents spaces where there shouldn't be
-                builder.replace(builder.length() - 1, builder.length(), "");
             builder.append(result.renderedSection());
             String appliedKey = result.appliedKey();
             if (appliedKey != null) {

--- a/src/main/java/com/renomad/minum/templating/TemplateSection.java
+++ b/src/main/java/com/renomad/minum/templating/TemplateSection.java
@@ -48,28 +48,6 @@ class TemplateSection {
         this.isOptional = isOptional;
     }
 
-        /**
-     * @param indent the column number, measured from the left, of the first character of this template key.  This is used
-     *               to indent the subsequent lines of text when there are newlines in the replacement
-     *               text. For example, if the indent is 5, and the value is "a", then it should indent like this:
-     *               <br>
-     *               <pre>{@code
-     *               12345
-     *                   a
-     *               }</pre>
-     * @param key the name of the key, e.g. "name", or "color"
-     * @param subString the template content around the keys.  For example, in the text
-     *                  of "my favorite color is {{ color }} and I like it",
-     *                  it would generate three template sections - "my favorite color is" would be
-     *                  the first subString, then a key of "color", then a third subString of "and I like it"
-     */
-    public TemplateSection(String key, String subString, int indent) {
-        this.key = key;
-        this.subString = subString;
-        this.indent = indent;
-        this.isOptional = false;
-    }
-
     /**
      * It would be absurd to send a million lines to a browser, much
      * less ten million.  This is here to set an upper limit on

--- a/src/test/java/com/renomad/minum/templating/TemplateSectionTests.java
+++ b/src/test/java/com/renomad/minum/templating/TemplateSectionTests.java
@@ -12,7 +12,7 @@ public class TemplateSectionTests {
 
     @Test
     public void test_MissingKeyAndSubstring() {
-        var templateSection = new TemplateSection(null, null, 0);
+        var templateSection = new TemplateSection(null, null, 0, false);
         assertThrows(InvariantException.class,
                 "Either the key or substring must exist",
                 () -> templateSection.render(null));
@@ -20,7 +20,7 @@ public class TemplateSectionTests {
 
     @Test
     public void test_HavingKeyAndSubstring() {
-        var templateSection = new TemplateSection("key", "substring", 0);
+        var templateSection = new TemplateSection("key", "substring", 0, false);
         assertThrows(InvariantException.class,
                 "If this object has a substring, then it must not have a key",
                 () -> templateSection.render(null));
@@ -67,7 +67,7 @@ public class TemplateSectionTests {
      */
     @Test
     public void test_indenting_edgeCase_NoIndent() {
-        TemplateSection templateSection = new TemplateSection("abc", null, 5);
+        TemplateSection templateSection = new TemplateSection("abc", null, 5, false);
         RenderingResult render = templateSection.render(Map.of("abc", "foo foo"));
         assertEquals(render.renderedSection(), "foo foo");
     }
@@ -77,7 +77,7 @@ public class TemplateSectionTests {
      */
     @Test
     public void test_indenting_edgeCase_WithIndent() {
-        TemplateSection templateSection = new TemplateSection("abc", null, 5);
+        TemplateSection templateSection = new TemplateSection("abc", null, 5, false);
         RenderingResult render = templateSection.render(Map.of("abc", "foo foo\nbar bar"));
         assertEquals(render.renderedSection(), "foo foo\n    bar bar");
     }

--- a/src/test/java/com/renomad/minum/templating/TemplateSectionTests.java
+++ b/src/test/java/com/renomad/minum/templating/TemplateSectionTests.java
@@ -35,7 +35,7 @@ public class TemplateSectionTests {
         var sb = new StringBuilder();
         ArrayList<TemplateSection> templateSections = new ArrayList<>();
 
-        StringBuilder result = TemplateProcessor.processSectionOutside(sb, templateSections, 0);
+        StringBuilder result = TemplateProcessor.processSectionOutside(sb, templateSections, 0, false);
 
         assertTrue(sb == result);
     }
@@ -49,7 +49,7 @@ public class TemplateSectionTests {
         var sb = new StringBuilder().append("hello world");
         ArrayList<TemplateSection> templateSections = new ArrayList<>();
 
-        StringBuilder result = TemplateProcessor.processSectionOutside(sb, templateSections, 0);
+        StringBuilder result = TemplateProcessor.processSectionOutside(sb, templateSections, 0, false);
 
         assertEquals(result.toString(), "");
         assertEquals(templateSections.getFirst().key, "hello world");

--- a/src/test/java/com/renomad/minum/templating/TemplatingTests.java
+++ b/src/test/java/com/renomad/minum/templating/TemplatingTests.java
@@ -118,6 +118,17 @@ public class TemplatingTests {
         assertEquals(result, "test1 foo }}");
     }
 
+    @Test
+    public void test_Template_Complex1_Optional() {
+        String template = "{{ name? }} foo }}";
+        var tp = buildProcessor(template);
+        Map<String, String> name = Map.of();
+
+        String result = tp.renderTemplate(name);
+
+        assertEquals(result, " foo }}");
+    }
+
     /**
      * What should happen if the brackets aren't closed?
      */
@@ -195,4 +206,39 @@ public class TemplatingTests {
         assertEquals(result, expected);
     }
 
+    @Test
+    public void test_Template_Optional_Keys_All_Present() {
+        TemplateProcessor templateProcessor = TemplateProcessor.buildProcessor("foo {{ bar? }} {{ baz? }}");
+        String expected = "foo bar baz";
+        String result = templateProcessor.renderTemplate(Map.of("bar", "bar", "baz", "baz"));
+
+        assertEquals(result, expected);
+    }
+
+    @Test
+    public void test_Template_Optional_Keys_Some_Present() {
+        TemplateProcessor templateProcessor = TemplateProcessor.buildProcessor("foo {{ bar? }} {{ baz? }}");
+        String expected = "foo baz";
+        String result = templateProcessor.renderTemplate(Map.of("baz", "baz"));
+
+        assertEquals(result, expected);
+    }
+
+    @Test
+    public void test_Template_Optional_Keys_None_present() {
+        TemplateProcessor templateProcessor = TemplateProcessor.buildProcessor("foo {{ bar? }} {{ baz? }}");
+        String expected = "foo";
+        String result = templateProcessor.renderTemplate(Map.of());
+
+        assertEquals(result, expected);
+    }
+
+    @Test
+    public void test_Template_Only_Optional_Keys() {
+        TemplateProcessor templateProcessor = TemplateProcessor.buildProcessor("{{ bar? }} {{ baz? }}");
+        String expected = "bar";
+        String result = templateProcessor.renderTemplate(Map.of("bar", "bar"));
+
+        assertEquals(result, expected);
+    }
 }

--- a/src/test/java/com/renomad/minum/templating/TemplatingTests.java
+++ b/src/test/java/com/renomad/minum/templating/TemplatingTests.java
@@ -218,7 +218,7 @@ public class TemplatingTests {
     @Test
     public void test_Template_Optional_Keys_Some_Present() {
         TemplateProcessor templateProcessor = TemplateProcessor.buildProcessor("foo {{ bar? }} {{ baz? }}");
-        String expected = "foo baz";
+        String expected = "foo  baz";
         String result = templateProcessor.renderTemplate(Map.of("baz", "baz"));
 
         assertEquals(result, expected);
@@ -227,7 +227,7 @@ public class TemplatingTests {
     @Test
     public void test_Template_Optional_Keys_None_present() {
         TemplateProcessor templateProcessor = TemplateProcessor.buildProcessor("foo {{ bar? }} {{ baz? }}");
-        String expected = "foo";
+        String expected = "foo  ";
         String result = templateProcessor.renderTemplate(Map.of());
 
         assertEquals(result, expected);
@@ -236,8 +236,17 @@ public class TemplatingTests {
     @Test
     public void test_Template_Only_Optional_Keys() {
         TemplateProcessor templateProcessor = TemplateProcessor.buildProcessor("{{ bar? }} {{ baz? }}");
-        String expected = "bar";
+        String expected = "bar ";
         String result = templateProcessor.renderTemplate(Map.of("bar", "bar"));
+
+        assertEquals(result, expected);
+    }
+
+    @Test
+    public void test_Template_Only_Optional_Keys_Missing_NoSpace() {
+        TemplateProcessor templateProcessor = TemplateProcessor.buildProcessor("foo{{ bar? }}");
+        String expected = "foo";
+        String result = templateProcessor.renderTemplate(Map.of());
 
         assertEquals(result, expected);
     }


### PR DESCRIPTION
Example syntax: `{{ foo? }}`

This allows keys to be omitted when rendering a templates, something I came across a use for in a  small project I'm working on in which the objects I'm trying to render may or may not have certain attributes, and needing to include all attributes as empty strings was awkward (there were quite a lot of them).

[--- I REMOVED THIS BEHAVIOUR ---](https://github.com/byronka/minum/pull/10#issuecomment-2323020631)
There is a slight quirk, as I'll demonstrate:
Given the template

`foo {{ bar? }} baz`

Then rendering without passing `baz`, the result will be

`foo baz`

Notice that there is only ONE space character, whereas the template string has two. I implemented this intentionally, however could remove if you think it would be better (i.e. to make the output `foo  baz`). Since we're generally using this to render HTML, it shouldn't matter a huge amount, but I thought for other use cases this might be a better solution.