### PR TITLE
Add Module Descriptors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,8 @@ SYSTEM_RUNNING
 # One of the functional tests puts a file in the static directory that is very large.
 # we don't want to add this to our repo.
 src/test/webapp/static/largefile.txt
+
+# Eclipse config files
 *.prefs
 .classpath
 .project

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ SYSTEM_RUNNING
 # One of the functional tests puts a file in the static directory that is very large.
 # we don't want to add this to our repo.
 src/test/webapp/static/largefile.txt
+*.prefs
+.classpath
+.project

--- a/docs/howto/jlink.md
+++ b/docs/howto/jlink.md
@@ -1,0 +1,41 @@
+# Creating Application images with Jlink and Minum
+
+## 1. Copy all your dependencies to `target/modules`
+
+The following plugin configuration will copy the application jar and all the runtime dependencies to `target/modules`.
+```xml
+<plugin>
+				<artifactId>maven-dependency-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>copy-modules</id>
+						<phase>package</phase>
+						<goals>
+							<goal>copy-dependencies</goal>
+						</goals>
+						<configuration>
+							<outputDirectory>${project.build.directory}/modules</outputDirectory>
+							<includeScope>runtime</includeScope>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-jar-plugin</artifactId>
+				<configuration>
+					<outputDirectory>${project.build.directory}/modules</outputDirectory>
+				</configuration>
+			</plugin>
+```
+## 2. Use Jlink to create a slim Java Runtime (JRT) with only the modules required to run the application
+
+```shell
+jlink --add-modules <your.module> --module-path target/modules --output /target/jrt
+```
+
+## 3. Run the application
+
+```shell
+./target/jrt/bin/java -m <your.module>/<main.class>
+```

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -1,0 +1,14 @@
+module com.renomad.minum {
+
+  exports com.renomad.minum.database;
+  exports com.renomad.minum.htmlparsing;
+  exports com.renomad.minum.logging;
+  exports com.renomad.minum.queue;
+  exports com.renomad.minum.security;
+  exports com.renomad.minum.state;
+  exports com.renomad.minum.templating;
+  exports com.renomad.minum.testing;
+  exports com.renomad.minum.utils;
+  exports com.renomad.minum.web;
+
+}


### PR DESCRIPTION
Now we can use `jlink` to[ create small runtimes](https://dev.java/learn/jlink/) with this library. 

- adds a `module-info.java` definition (if you want to encapsulate any packages, I can omit them)
- adds a basic guide for using jlink