### PR TITLE
Make getServer and getSslServer public

### DIFF
--- a/src/main/java/com/renomad/minum/web/FullSystem.java
+++ b/src/main/java/com/renomad/minum/web/FullSystem.java
@@ -123,7 +123,7 @@ public final class FullSystem {
         } else {
             theBrig = null;
         }
-        
+
         // the web framework handles the HTTP communications
         webFramework = new WebFramework(context);
 
@@ -162,11 +162,11 @@ public final class FullSystem {
         new File("SYSTEM_RUNNING").deleteOnExit();
     }
 
-    IServer getServer() {
+    public IServer getServer() {
         return server;
     }
 
-    IServer getSslServer() {
+    public IServer getSslServer() {
         return sslServer;
     }
 


### PR DESCRIPTION
Fixes: https://github.com/byronka/minum/issues/23

I'd like to make getServer public in the scenario where the port is automatically assigned by the runtime. We can achieve the automatically assigned port by setting `PORT` to `0`.

Making getServer public means I will be able to retrieve the automatically assigned port.

This is used in https://github.com/tanin47/java-electron (Electron for Java) where Minum will choose an available port and open a server on that port. 

Alternatively, I could choose a hardcoded port but that would incur the risk of the hardcoded port being used by another application. Therefore, this alternative is inferior.

Test isn't applicable in this PR.

Thank you!